### PR TITLE
Fix wrong file size units

### DIFF
--- a/Libs/Celeste_Public_Api/Helpers/Misc.cs
+++ b/Libs/Celeste_Public_Api/Helpers/Misc.cs
@@ -30,8 +30,8 @@ namespace Celeste_Public_Api.Helpers
         {
             string[] suffixes =
             {
-                "bytes", "KB", "MB", "GB",
-                "TB", "PB", "EB", "ZB", "YB"
+                "bytes", "KiB", "MiB", "GiB",
+                "TiB", "PiB", "EiB", "ZiB", "YiB"
             };
 
             for (var i = 0; i < suffixes.Length; i++)


### PR DESCRIPTION
Changed KB to KiB so it correctly fits a 1024 power.
KB = 1000 bytes
KiB = 1024 bytes (standard unit)