### PR TITLE
Vertically center overview sidebar menu items

### DIFF
--- a/Celeste_Launcher_Gui/Pages/OverviewPage.xaml
+++ b/Celeste_Launcher_Gui/Pages/OverviewPage.xaml
@@ -25,8 +25,8 @@
     </Page.Resources>
     <Grid>
         <Image Source="pack://application:,,,/Celeste_Launcher_Gui;component/Resources/LoggedInScreenSeparators.png" Margin="0,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" />
-        <Grid Height="357" Margin="0,0,0,0" VerticalAlignment="Top" HorizontalAlignment="Left" Width="186">
-        <StackPanel HorizontalAlignment="Center" Margin="0,10,0,0">
+        <Grid Height="331" Margin="0,0,0,0" VerticalAlignment="Top" HorizontalAlignment="Left" Width="186">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
             <local:SideBarMenuItem
                 LabelContents="{x:Static p:Resources.OverviewAccountSideMenuBtn}" 
                 DefaultIcon="pack://application:,,,/Celeste_Launcher_Gui;component/Resources/Icons/Account-Normal.png"
@@ -85,7 +85,7 @@
 
         <!-- topright 188x421 -->
         <Grid Margin="776,0,0,0" VerticalAlignment="Top" HorizontalAlignment="Left" Width="187" Height="421">
-            <StackPanel HorizontalAlignment="Center" Margin="0,10,0,0">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                 <local:SideBarMenuItemRight
                     LabelContents="{x:Static p:Resources.OverviewWebsiteSideMenuBtn}" 
                     DefaultIcon="pack://application:,,,/Celeste_Launcher_Gui;component/Resources/Icons/Website-Normal.png"


### PR DESCRIPTION
# Description
Vertically centers the side bar menu items on the overview screen.

Current:
![](https://forums.projectceleste.com/attachments/azbspzl-png.1414/)
Proposed change (vertically centered icons):
![](https://i.shikashi.me/0LvZK)
