### PR TITLE
Fixed issue preventing GameFilesPath to update after path selection

### DIFF
--- a/Celeste_Launcher_Gui/Services/GameService.cs
+++ b/Celeste_Launcher_Gui/Services/GameService.cs
@@ -45,19 +45,20 @@ namespace Celeste_Launcher_Gui.Services
                 Logger.Information("User is online, will perform game scan");
                 try
                 {
-                    var gameFilePath = !string.IsNullOrWhiteSpace(LegacyBootstrapper.UserConfig.GameFilesPath)
-                        ? LegacyBootstrapper.UserConfig.GameFilesPath
-                        : GameScannerManager.GetGameFilesRootPath();
-
-                    Logger.Information("Preparing games canner api");
-                    var gameScannner = new GameScannerManager(gameFilePath, LegacyBootstrapper.UserConfig.IsSteamVersion);
-                    await gameScannner.InitializeFromCelesteManifest();
-
                     var success = false;
 
                     while (!success)
                     {
                         Logger.Information("Starting quick game scan");
+                        var gameFilePath = !string.IsNullOrWhiteSpace(LegacyBootstrapper.UserConfig.GameFilesPath)
+                            ? LegacyBootstrapper.UserConfig.GameFilesPath 
+                            : GameScannerManager.GetGameFilesRootPath();
+
+                        Logger.Information("Preparing games canner api");
+
+                        var gameScannner = new GameScannerManager(gameFilePath, LegacyBootstrapper.UserConfig.IsSteamVersion);
+                        await gameScannner.InitializeFromCelesteManifest();
+
                         if (!await gameScannner.Scan(true))
                         {
                             Logger.Information("Game scanner did not approve game files");
@@ -69,8 +70,8 @@ namespace Celeste_Launcher_Gui.Services
 
                             if (dialogResult.Value)
                             {
-                                var scanner = new GamePathSelectionWindow();
-                                scanner.ShowDialog();
+                                var gamePathSelectionWindow = new GamePathSelectionWindow();
+                                gamePathSelectionWindow.ShowDialog();
                             }
                             else
                             {


### PR DESCRIPTION
# Description
Fixes this bug: https://trello.com/c/vW4jd9VM/170-game-scanner-is-refusing-to-launch-the-game-at-first-launch-after-selecting-the-game-path
Root cause was that when the player had their game path selected, it did not get updated in the game scanner as the game scanner would still be configured with the old game path.
