### PR TITLE
Require Spartan.exe to be in same path when converting to steam

### DIFF
--- a/Celeste_Launcher_Gui/Windows/SteamConverterWindow.xaml.cs
+++ b/Celeste_Launcher_Gui/Windows/SteamConverterWindow.xaml.cs
@@ -46,6 +46,13 @@ namespace Celeste_Launcher_Gui.Windows
 
                 var currentWorkingDirectory = Path.GetDirectoryName(currentApplicationFullPath);
 
+                if (!File.Exists($"{currentWorkingDirectory}\\Spartan.exe"))
+                {
+                    GenericMessageDialog.Show(Properties.Resources.SteamConverterIncorrectInstallationDirectory, DialogIcon.None, DialogOptions.Ok);
+                    Close();
+                    return;
+                }
+
                 LegacyBootstrapper.UserConfig.GameFilesPath = currentWorkingDirectory;
                 LegacyBootstrapper.UserConfig.Save(LegacyBootstrapper.UserConfigFilePath);
 


### PR DESCRIPTION
This reverts commit 537fcd749d7cbb3ffb6e1dca6acffff30f8852e3.

# Description


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings