### PR TITLE
Fixed Launcher Crashing if Color Picker is used before a Game Scan

### DIFF
--- a/Celeste_Launcher_Gui/Pages/OverviewPage.xaml.cs
+++ b/Celeste_Launcher_Gui/Pages/OverviewPage.xaml.cs
@@ -271,6 +271,11 @@ namespace Celeste_Launcher_Gui.Pages
 
         private void OpenPlayerColors(object sender, RoutedEventArgs e)
         {
+            if (!File.Exists(PlayerColorsXML()))
+            {
+                GenericMessageDialog.Show(Properties.Resources.ColorPickerGamePathNotYetSet);
+                return;
+            }
             var colorWindow = new SetPlayerColorWindow();
             colorWindow.Owner = Window.GetWindow(this);
             colorWindow.ShowDialog();
@@ -333,5 +338,7 @@ namespace Celeste_Launcher_Gui.Pages
             ToolsButton.ContextMenu.PlacementTarget = sender as UIElement;
             ToolsButton.ContextMenu.IsOpen = true;
         }
+        private static string PlayerColorsXML()
+            => Path.Combine(LegacyBootstrapper.UserConfig.GameFilesPath, "Data", "playercolors.xml");
     }
 }


### PR DESCRIPTION
Fixed a Launcher crash if a player has an outdated game, uses the Color Picker, then tries to hit the Play button. The Launcher crash happens before the Game Scan check. If playercolor.xml doesn't exist, the Color Picker will give the appropriate message that a game scan is required. This fixes Issue #115 