### PR TITLE
Enable Limit CPU Cores by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Change Log
+## [3.17.2](https://github.com/ProjectCeleste/Celeste.Launcher/releases/tag/v3.16.5) (2026-02-21)
+- Enable Limit CPU Cores by default - CWO333
+
+## [3.17.1](https://github.com/ProjectCeleste/Celeste.Launcher/releases/tag/v3.16.5) (2026-02-14)
+- Fixed Launcher Crashing if Color Picker is used before a Game Scan (thanks CWO333)
+
+## [3.17.0](https://github.com/ProjectCeleste/Celeste.Launcher/releases/tag/v3.16.5) (2026-02-14)
+- Add ViewLog button to error messageboxes (thanks NCSGeek)
+
 ## [3.16.5](https://github.com/ProjectCeleste/Celeste.Launcher/releases/tag/v3.16.5) (2025-10-29)
 - Fixed a bug with Steam converter that caused the launcher to crash (thanks CWO333)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Change Log
-## [3.17.2](https://github.com/ProjectCeleste/Celeste.Launcher/releases/tag/v3.16.5) (2026-02-21)
+## [3.17.2](https://github.com/ProjectCeleste/Celeste.Launcher/releases/tag/v3.17.2) (2026-02-21)
 - Enable Limit CPU Cores by default - CWO333
 
-## [3.17.1](https://github.com/ProjectCeleste/Celeste.Launcher/releases/tag/v3.16.5) (2026-02-14)
+## [3.17.1](https://github.com/ProjectCeleste/Celeste.Launcher/releases/tag/v3.17.1) (2026-02-14)
 - Fixed Launcher Crashing if Color Picker is used before a Game Scan (thanks CWO333)
 
-## [3.17.0](https://github.com/ProjectCeleste/Celeste.Launcher/releases/tag/v3.16.5) (2026-02-14)
+## [3.17.0](https://github.com/ProjectCeleste/Celeste.Launcher/releases/tag/v3.17.0) (2026-02-14)
 - Add ViewLog button to error messageboxes (thanks NCSGeek)
 
 ## [3.16.5](https://github.com/ProjectCeleste/Celeste.Launcher/releases/tag/v3.16.5) (2025-10-29)

--- a/Celeste_Launcher_Gui/Config.cs
+++ b/Celeste_Launcher_Gui/Config.cs
@@ -66,7 +66,9 @@ namespace Celeste_Launcher_Gui
         [XmlElement(ElementName = "IsDiagnosticMode")]
         public bool IsDiagnosticMode { get; set; }
 
-        public bool LimitCPUCores { get; set; }
+        [DefaultValue(true)]
+        [XmlElement(ElementName = "LimitCPUCores")]
+        public bool LimitCPUCores { get; set; } = true;
 
         public static UserConfig Load(string path)
         {


### PR DESCRIPTION
> Updated the changelog to include a couple changes done previously.
> Enable the CPU Limit by default.

Originally when implementing the CPU Limit option, we didn't have as many people with issues so the thought was, don't fix what isn't broken for a majority of our players. But lately, we have had numerous reports from new or returning players with issues. After being suggested a few times, I think it's time to enable the CPU Limit by default.