### PR TITLE
Add msvcp140.dll version check

### DIFF
--- a/Celeste_Launcher_Gui/Properties/Resources.Designer.cs
+++ b/Celeste_Launcher_Gui/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Celeste_Launcher_Gui.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -1133,6 +1133,15 @@ namespace Celeste_Launcher_Gui.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Your Visual C++ Runtime is outdated or missing.\nThe game will likely crash without updating.\nDownload the Runtime installer now?.
+        /// </summary>
+        public static string MSVCPUpdateNeeded {
+            get {
+                return ResourceManager.GetString("MSVCPUpdateNeeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Connection Type.
         /// </summary>
         public static string MultiplayerSettingsConnectionTypeTitle {
@@ -1284,7 +1293,7 @@ namespace Celeste_Launcher_Gui.Properties {
                 return ResourceManager.GetString("OptionOk", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Open Log.
         /// </summary>
@@ -1293,7 +1302,7 @@ namespace Celeste_Launcher_Gui.Properties {
                 return ResourceManager.GetString("OptionOpenLog", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Yes.
         /// </summary>

--- a/Celeste_Launcher_Gui/Properties/Resources.de-DE.resx
+++ b/Celeste_Launcher_Gui/Properties/Resources.de-DE.resx
@@ -838,7 +838,6 @@ Age of Empires Online - Celeste Fan Project</value>
   <data name="ServerResponse_USERNAME_ALREADY_TAKEN" xml:space="preserve">
     <value>Dieser Benutzername ist schon vergeben.</value>
   </data>
-
   <data name="ColorPickerGamePathNotYetSet" xml:space="preserve">
     <value>Bevor du die Farben änderst, musst du erst mal einen Spiel-Scan machen.</value>
   </data>
@@ -931,5 +930,8 @@ Age of Empires Online - Celeste Fan Project</value>
   </data>
   <data name="ColorPickerWindowTitle" xml:space="preserve">
     <value>Farbwähler</value>
+  </data>
+  <data name="MSVCPUpdateNeeded" xml:space="preserve">
+    <value>Ihre Visual C++-Runtime ist veraltet oder fehlt.\nDas Spiel wird ohne Aktualisierung wahrscheinlich abstürzen.\nDen Runtime-Installer jetzt herunterladen?</value>
   </data>
 </root>

--- a/Celeste_Launcher_Gui/Properties/Resources.es-ES.resx
+++ b/Celeste_Launcher_Gui/Properties/Resources.es-ES.resx
@@ -931,4 +931,7 @@ Age of Empires Online - Celeste Fan Project</value>
   <data name="ColorPickerWindowTitle" xml:space="preserve">
     <value>Selector de color</value>
   </data>
+  <data name="MSVCPUpdateNeeded" xml:space="preserve">
+    <value>Su entorno de ejecución de Visual C++ está desactualizado o falta.\nEs probable que el juego se bloquee sin actualizarlo.\n¿Descargar ahora el instalador del entorno de ejecución?</value>
+  </data>
 </root>

--- a/Celeste_Launcher_Gui/Properties/Resources.fr-FR.resx
+++ b/Celeste_Launcher_Gui/Properties/Resources.fr-FR.resx
@@ -940,4 +940,7 @@ Age of Empires Online - Celeste Fan Project</value>
   <data name="ColorPickerWindowTitle" xml:space="preserve">
     <value>Sélecteur de couleur</value>
   </data>
+  <data name="MSVCPUpdateNeeded" xml:space="preserve">
+    <value>Votre environnement d’exécution Visual C++ est obsolète ou manquant.\nLe jeu risque de planter sans mise à jour.\nTélécharger l’installateur de l’environnement d’exécution maintenant?</value>
+  </data>
 </root>

--- a/Celeste_Launcher_Gui/Properties/Resources.it-IT.resx
+++ b/Celeste_Launcher_Gui/Properties/Resources.it-IT.resx
@@ -839,7 +839,7 @@ Age of Empires Online - Celeste Fan Project</value>
     <value>Questo nome utente è già stato utilizzato.</value>
   </data>
   <data name="ColorPickerGamePathNotYetSet" xml:space="preserve">
-	  <value>Devi prima eseguire una scansione del gioco prima di modificare i colori.</value>
+    <value>Devi prima eseguire una scansione del gioco prima di modificare i colori.</value>
   </data>
   <data name="ColorPickerTitleColor" xml:space="preserve">
     <value>Colore</value>
@@ -930,5 +930,8 @@ Age of Empires Online - Celeste Fan Project</value>
   </data>
   <data name="ColorPickerWindowTitle" xml:space="preserve">
     <value>Selettore colore</value>
+  </data>
+  <data name="MSVCPUpdateNeeded" xml:space="preserve">
+    <value>Il runtime di Visual C++ è obsoleto o mancante.\nIl gioco potrebbe bloccarsi senza un aggiornamento.\nScaricare ora il programma di installazione del runtime?</value>
   </data>
 </root>

--- a/Celeste_Launcher_Gui/Properties/Resources.pt-BR.resx
+++ b/Celeste_Launcher_Gui/Properties/Resources.pt-BR.resx
@@ -860,10 +860,13 @@ Age of Empires Online - Projeto de Fãs Celeste</value>
   <data name="ColorPickerRedFoe" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
+  <data name="ColorPickerWindowTitle" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
   <data name="ColorPickerPlayer" xml:space="preserve">
     <value>Player</value>
   </data>
-  <data name="ColorPickerWindowTitle" type="System.Resources.ResXNullRef, System.Windows.Forms">
-    <value />
+  <data name="MSVCPUpdateNeeded" xml:space="preserve">
+    <value>Seu runtime do Visual C++ está desatualizado ou ausente.\nO jogo provavelmente vai travar sem uma atualização.\nBaixar o instalador do runtime agora?</value>
   </data>
 </root>

--- a/Celeste_Launcher_Gui/Properties/Resources.resx
+++ b/Celeste_Launcher_Gui/Properties/Resources.resx
@@ -940,4 +940,7 @@ Age of Empires Online - Celeste Fan Project</value>
   <data name="ColorPickerWindowTitle" xml:space="preserve">
     <value>Color Picker</value>
   </data>
+  <data name="MSVCPUpdateNeeded" xml:space="preserve">
+    <value>Your Visual C++ Runtime is outdated or missing.\nThe game will likely crash without updating.\nDownload the Runtime installer now?</value>
+  </data>
 </root>

--- a/Celeste_Launcher_Gui/Properties/Resources.zh-CHT.resx
+++ b/Celeste_Launcher_Gui/Properties/Resources.zh-CHT.resx
@@ -919,4 +919,7 @@ Age of Empires Online - Celeste Fan Project</value>
   <data name="ColorPickerWindowTitle" xml:space="preserve">
     <value>颜色选取</value>
   </data>
+  <data name="MSVCPUpdateNeeded" xml:space="preserve">
+    <value>您的 Visual C++ 執行階段已過時或遺失。\n如果不更新，遊戲很可能會當機。\n要立即下載執行階段安裝程式嗎？</value>
+  </data>
 </root>

--- a/Celeste_Launcher_Gui/Services/GameService.cs
+++ b/Celeste_Launcher_Gui/Services/GameService.cs
@@ -43,8 +43,8 @@ namespace Celeste_Launcher_Gui.Services
 
             try
             {
-                string dllPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.SystemX86), "msvcp140.dll");
-                bool msvcpInsufficient = false;
+                var dllPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.SystemX86), "msvcp140.dll");
+                var msvcpInsufficient = false;
 
                 if (!File.Exists(dllPath))
                 {
@@ -87,7 +87,7 @@ namespace Celeste_Launcher_Gui.Services
             }
             catch (Exception ex)
             {
-                Logger.Warning(ex, "Could not verify MSVC runtime version, proceeding anyway");
+                Logger.Warning(ex, "Could not verify MSVC runtime version, proceeding anyway. Error Message: " + ex.Message);
             }
 
             BackupOrRestorePlayerColors();

--- a/Celeste_Launcher_Gui/Services/GameService.cs
+++ b/Celeste_Launcher_Gui/Services/GameService.cs
@@ -45,12 +45,12 @@ namespace Celeste_Launcher_Gui.Services
             try
             {
                 var dllPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.SystemX86), "msvcp140.dll");
-                var msvcpInsufficient = false;
+                var msvcpOutdated = false;
 
                 if (!File.Exists(dllPath))
                 {
                     Logger.Warning("msvcp140.dll not found at {@path}", dllPath);
-                    msvcpInsufficient = true;
+                    msvcpOutdated = true;
                 }
                 else
                 {
@@ -61,11 +61,11 @@ namespace Celeste_Launcher_Gui.Services
                     if (version < new Version(14, 40, 0, 0))
                     {
                         Logger.Warning("msvcp140.dll version too old: {@version}", version);
-                        msvcpInsufficient = true;
+                        msvcpOutdated = true;
                     }
                 }
 
-                if (msvcpInsufficient)
+                if (msvcpOutdated)
                 {
                     var dialog = new GenericMessageDialog(
                         Resources.MSVCPUpdateNeeded,

--- a/Celeste_Launcher_Gui/Services/GameService.cs
+++ b/Celeste_Launcher_Gui/Services/GameService.cs
@@ -41,6 +41,55 @@ namespace Celeste_Launcher_Gui.Services
                 return;
             }
 
+            try
+            {
+                string dllPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.SystemX86), "msvcp140.dll");
+                bool msvcpInsufficient = false;
+
+                if (!File.Exists(dllPath))
+                {
+                    Logger.Warning("msvcp140.dll not found at {@path}", dllPath);
+                    msvcpInsufficient = true;
+                }
+                else
+                {
+                    var versionInfo = FileVersionInfo.GetVersionInfo(dllPath);
+                    var version = new Version(versionInfo.FileMajorPart, versionInfo.FileMinorPart,
+                                               versionInfo.FileBuildPart, versionInfo.FilePrivatePart);
+
+                    if (version < new Version(14, 40, 0, 0))
+                    {
+                        Logger.Warning("msvcp140.dll version too old: {@version}", version);
+                        msvcpInsufficient = true;
+                    }
+                }
+
+                if (msvcpInsufficient)
+                {
+                    var dialog = new GenericMessageDialog(
+                        "Your Visual C++ Runtime is outdated or missing.\n" +
+                        "The game will likely crash without updating.\n" +
+                        "Download the Runtime installer now?",
+                        DialogIcon.Warning,
+                        DialogOptions.YesNo);
+
+                    var dr = dialog.ShowDialog();
+                    if (dr.Value == true)
+                    {
+                        Process.Start(new ProcessStartInfo("https://aka.ms/vs/17/release/vc_redist.x86.exe")
+                        {
+                            UseShellExecute = true
+                        });
+                        return;
+                    }
+                    
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "Could not verify MSVC runtime version, proceeding anyway");
+            }
+
             BackupOrRestorePlayerColors();
 
             //QuickGameScan

--- a/Celeste_Launcher_Gui/Services/GameService.cs
+++ b/Celeste_Launcher_Gui/Services/GameService.cs
@@ -1,4 +1,5 @@
 ﻿using Celeste_Launcher_Gui.Helpers;
+using Celeste_Launcher_Gui.Properties;
 using Celeste_Launcher_Gui.Win32;
 using Celeste_Launcher_Gui.Windows;
 using Celeste_Public_Api.Helpers;
@@ -67,9 +68,7 @@ namespace Celeste_Launcher_Gui.Services
                 if (msvcpInsufficient)
                 {
                     var dialog = new GenericMessageDialog(
-                        "Your Visual C++ Runtime is outdated or missing.\n" +
-                        "The game will likely crash without updating.\n" +
-                        "Download the Runtime installer now?",
+                        Resources.MSVCPUpdateNeeded,
                         DialogIcon.Warning,
                         DialogOptions.YesNo);
 


### PR DESCRIPTION
Add a check that msvcp140.dll is >= v14.40. This is needed because of [this](https://stackoverflow.com/questions/78598141/first-stdmutexlock-crashes-in-application-built-with-latest-visual-studio) bug which causes the game to silently crash with no error logged anywhere as to why.